### PR TITLE
Updating references from "master" to "main"

### DIFF
--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,9 +1,9 @@
 production:
-  auto_deploy_on: refs/heads/master
+  auto_deploy_on: refs/heads/main
   environment: production
   required_contexts: ["build (10.x)", "deliverybot/promotion"]
 
 development:
-  auto_deploy_on: refs/heads/master
+  auto_deploy_on: refs/heads/main
   environment: development
   required_contexts: ["build (10.x)"]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: 8.x
 
     - name: 'deployment pending'
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@main'
       with:
         state: 'pending'
         token: '${{ github.token }}'
@@ -39,14 +39,14 @@ jobs:
 
     - name: 'deployment success'
       if: success()
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@main'
       with:
         state: 'success'
         token: '${{ github.token }}'
 
     - name: 'deployment failure'
       if: failure()
-      uses: 'deliverybot/deployment-status@master'
+      uses: 'deliverybot/deployment-status@main'
       with:
         state: 'failure'
         token: '${{ github.token }}'


### PR DESCRIPTION
Hey @kennsippell, 

I've started to work on ticket https://github.com/medic/cht-core/issues/6574, and as part of it, I'm changing a lot of repositories to update their default branch name from "master" to "main".  In most cases, the change is safe, but some minor details need manual changes to ensure the references are correctly updated.

Can you please look at my changes here to make sure they are OK?

Thanks,
Jonathan